### PR TITLE
[Enhancement] Added .udp_bind() and .udp_bind_or()

### DIFF
--- a/examples/main.rs
+++ b/examples/main.rs
@@ -13,7 +13,10 @@ struct Cli {
 
 fn main() -> Result<(), std::io::Error> {
   let args = Cli::from_args();
-  let tcp_listener = args.port.bind_or(8080)?;
-  println!("{:?}", tcp_listener);
+  let tcp_listener = args.port.tcp_bind_or(8080)?;
+  println!("TCP bind(or): {:?}", tcp_listener);
+
+  let udp_listener = args.port.udp_bind_or(4242)?;
+  println!("UDP bind(or): {:?}", udp_listener);
   Ok(())
 }


### PR DESCRIPTION
Adding `.udp_bind()` and `.udp_bind_or()` for feature request #7  

Renamed old `.bind()` and `.bind_or()` to `.tcp_bind()` and `.tcp_bind_or()` respectively. 

Included new `.udp_bind_or()` in examples/main 